### PR TITLE
Various small updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work/
 *~
+dist-newstyle/

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright Author name here (c) 2021
+Copyright Flipstone Technology Partners (c) 2021
 
 All rights reserved.
 

--- a/package.yaml
+++ b/package.yaml
@@ -7,8 +7,8 @@ maintainer:          "development@flipstone.com"
 copyright:           "2021 Flipstone Technology Partners, Inc"
 
 extra-source-files:
-- README.md
-- ChangeLog.md
+  - README.md
+  - ChangeLog.md
 
 # Metadata used when publishing your package
 # synopsis:            Short description of your package
@@ -19,9 +19,15 @@ extra-source-files:
 # common to point users to the README.md file.
 description:         Please see the README on GitHub at <https://github.com/flipstone/shrubbery#readme>
 
+flags:
+  ci:
+    description: More strict ghc options used for development and ci, not intended for end-use.
+    manual: true
+    default: false
+
 dependencies:
-- base >= 4.7 && < 5
-- primitive
+  - base >= 4.7 && < 5
+  - primitive
 
 library:
   source-dirs: src
@@ -32,20 +38,44 @@ library:
     - Shrubbery.BranchIndex
     - Shrubbery.Union
     - Shrubbery.TypeList
-
-ghc-options:
-  - -Wall
-  - -Werror
-  - -O2
+  when:
+    - condition: flag(ci)
+      then:
+        ghc-options:
+          - -O2
+          - -Wall
+          - -Werror
+          - -Wcompat
+          - -Widentities
+          - -Wincomplete-uni-patterns
+          - -Wincomplete-patterns
+          - -Wincomplete-record-updates
+          - -Wmissing-local-signatures
+          - -Wmissing-export-lists
+          - -Wnoncanonical-monad-instances
+          - -Wpartial-fields
+          - -Wmissed-specialisations
+          - -Wno-implicit-prelude
+          - -Wno-safe
+          - -Wno-unsafe
+      else:
+        ghc-options:
+          - -O2
+          - -Wall
+          - -fwarn-incomplete-uni-patterns
+          - -fwarn-incomplete-record-updates
 
 tests:
   shrubbery-test:
-    main:                Main.hs
-    source-dirs:         test
+    main: Main.hs
+    source-dirs: test
     ghc-options:
-    - -threaded
-    - -rtsopts
-    - -with-rtsopts=-N
+      - -threaded
+      - -rtsopts
+      - -with-rtsopts=-N
+      - -Wall
+      - -Werror
+      - -O2
     dependencies:
-    - shrubbery
-    - hedgehog
+      - shrubbery
+      - hedgehog

--- a/shrubbery.cabal
+++ b/shrubbery.cabal
@@ -6,12 +6,12 @@ cabal-version: 1.12
 
 name:           shrubbery
 version:        0.1.0.0
-description:    Please see the README on GitHub at <https://github.com/githubuser/shrubbery#readme>
-homepage:       https://github.com/githubuser/shrubbery#readme
-bug-reports:    https://github.com/githubuser/shrubbery/issues
-author:         Author name here
-maintainer:     example@example.com
-copyright:      2021 Author name here
+description:    Please see the README on GitHub at <https://github.com/flipstone/shrubbery#readme>
+homepage:       https://github.com/flipstone/shrubbery#readme
+bug-reports:    https://github.com/flipstone/shrubbery/issues
+author:         Flipstone Technology Partners, Inc
+maintainer:     development@flipstone.com
+copyright:      2021 Flipstone Technology Partners, Inc
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
@@ -21,7 +21,12 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/githubuser/shrubbery
+  location: https://github.com/flipstone/shrubbery
+
+flag ci
+  description: More strict ghc options used for development and ci, not intended for end-use.
+  manual: True
+  default: False
 
 library
   exposed-modules:
@@ -35,10 +40,13 @@ library
       Paths_shrubbery
   hs-source-dirs:
       src
-  ghc-options: -Wall -Werror -O2
   build-depends:
       base >=4.7 && <5
     , primitive
+  if flag(ci)
+    ghc-options: -O2 -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-patterns -Wincomplete-record-updates -Wmissing-local-signatures -Wmissing-export-lists -Wnoncanonical-monad-instances -Wpartial-fields -Wmissed-specialisations -Wno-implicit-prelude -Wno-safe -Wno-unsafe
+  else
+    ghc-options: -O2 -Wall -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   default-language: Haskell2010
 
 test-suite shrubbery-test
@@ -48,7 +56,7 @@ test-suite shrubbery-test
       Paths_shrubbery
   hs-source-dirs:
       test
-  ghc-options: -Wall -Werror -O2 -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall -Werror -O2
   build-depends:
       base >=4.7 && <5
     , hedgehog

--- a/src/Shrubbery/TypeList.hs
+++ b/src/Shrubbery/TypeList.hs
@@ -114,4 +114,3 @@ typesProxyToLengthProxy _ = Proxy
 type family Length (types :: [Type]) :: Nat where
   Length '[] = 0
   Length (_ : rest) = 1 + Length rest
-

--- a/src/Shrubbery/Union.hs
+++ b/src/Shrubbery/Union.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-|
   This module provides a implementation of a sum type whose members are
   known in the type sysem and provides implementations of 'Dissection'
@@ -15,7 +14,7 @@
     anInt = unify (0 :: Int)
 
     aString :: MyUnion
-    aString = unify "Foo"
+    aString = unify \"Foo\"
 
     doSomething :: MyUnion -> String
     doSomething =

--- a/stack-gh-pages-haddock.sh
+++ b/stack-gh-pages-haddock.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+# Based on https://github.com/yamadapc/stack-gh-pages
+set -o errexit
+set -o xtrace
+
+mkdocs() {
+  package=$1
+  stack_yaml=$2
+  parent_dir=$(pwd)
+
+  docsdir="$parent_dir/haddocks"
+
+  cd "$package"
+
+  stack --stack-yaml "$stack_yaml" \
+       haddock \
+       --haddock-hyperlink-source \
+       --no-haddock-deps \
+       --force-dirty \
+       --haddock-arguments --odir=temp-docs
+
+  me=$(whoami)
+  sudo chown -R "$me"."$me" temp-docs
+  cd "$parent_dir"
+  rm -rf "$docsdir"
+  mv "$package/temp-docs" "$docsdir"
+}
+
+mkindex() {
+cat << END > index.html
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Shrubbery Documentation</title>
+  </head>
+  <body>
+    <h1>Documentation for yet-to-be released Shrubbery packages</h1>
+    <ul>
+      <li><a href="haddocks">shrubbery</a></li>
+    </ul>
+  </body>
+</html>
+END
+}
+
+push_to_pages_branch() {
+  git stash
+  git branch -D gh-pages || echo "No existing pages branch to delete"
+  git checkout --orphan gh-pages
+  git add .
+  git commit -m "Automated Haddock commit"
+  git checkout main
+
+  echo "Docs have been generated on the gh-pages branch."
+  echo "You can push make them live with the following command:"
+  echo ""
+  echo "  git push -f -u origin gh-pages:gh-pages"
+}
+
+mkdocs . stack.yaml
+mkindex
+push_to_pages_branch


### PR DESCRIPTION
- Adds Flipstone as the author in the LICENSE file.
- Adds a ci flag to the package.yaml/shrubbery.cabal to allow for more
  strict compiler flags but only during development.
- Cabal file now has correct homepage so it should flow through to
  haddocks correctly as well.
- Cabal file also now has correct author/maintainer/copyright, but
those do not go to haddocks, apparently.
- Fixed an escaping issue in haddocks that resulted in a link pointing
to nowhere.
- Removed an unused language extension (TypeOperators).
- Adds script to update haddocks.
- Updates gitignore to exclude cabal generated files as well as stack
ones.