### PR TITLE
Add nominal role annotation for TaggedUnion

### DIFF
--- a/src/Shrubbery/TaggedUnion.hs
+++ b/src/Shrubbery/TaggedUnion.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -39,6 +40,8 @@ import Shrubbery.Union (Union, dissectUnion)
 -}
 newtype TaggedUnion (taggedTypes :: [Tag])
   = TaggedUnion (Union (TaggedTypes taggedTypes))
+
+type role TaggedUnion nominal
 
 instance
   ( TaggedTypes taggedTypes ~ types

--- a/src/Shrubbery/Union.hs
+++ b/src/Shrubbery/Union.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -61,6 +62,8 @@ import Shrubbery.TypeList (KnownLength)
 -}
 data Union types where
   Union :: BranchIndex t types -> t -> Union types
+
+type role Union nominal
 
 instance (ShowBranches types, KnownLength types) => Show (Union types) where
   showsPrec = showsPrecViaDissect


### PR DESCRIPTION
Before this PR, you could `coerce` tagged unions even though they have different tags:

```
{-# LANGUAGE DataKinds, ExplicitNamespaces #-}                                      
module Main (main) where                                                            
                                                                                    
import Data.Coerce (coerce)                                                         
import Data.Int (Int32)                                                             
import Data.Text (Text)                                                             
import Lib (someFunc)                                                               
import Shrubbery (TaggedUnion)                                                      
import Shrubbery.TypeList (type (@=))                                               
                                                                                    
main :: IO ()                                                                       
main = someFunc                                                                     
                                                                                    
type Foo = TaggedUnion ["int" @= Int32, "text" @= Text]                             
                                                                                    
fromFoo :: Foo -> TaggedUnion '[]                                                   
fromFoo = coerce                                                                    
                                                                                    
toFoo :: TaggedUnion '[] -> Foo                                                     
toFoo = coerce
```

After this PR, it results in this error message:

```
app/Main.hs:22:11: error: [GHC-18872]
    • Couldn't match type: ["int" @= Int32, "text" @= Text]
                     with: '[]
        arising from a use of ‘coerce’
    • In the expression: coerce
      In an equation for ‘fromFoo’: fromFoo = coerce
   |             
22 | fromFoo = coerce
   |           ^^^^^^
                 
app/Main.hs:25:9: error: [GHC-18872]
    • Couldn't match type: '[]
                     with: ["int" @= Int32, "text" @= Text]
        arising from a use of ‘coerce’
    • In the expression: coerce
      In an equation for ‘toFoo’: toFoo = coerce
   |             
25 | toFoo = coerce
   |         ^^^^^^
```