### PR TITLE
Adds `matchUnion` and `matchTaggedUnion` functions

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                shrubbery
-version:             0.2.1.0
+version:             0.2.2.0
 github:              "flipstone/shrubbery"
 license:             BSD3
 author:              "Flipstone Technology Partners, Inc"

--- a/shrubbery.cabal
+++ b/shrubbery.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           shrubbery
-version:        0.2.1.0
+version:        0.2.2.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/shrubbery#readme>
 homepage:       https://github.com/flipstone/shrubbery#readme
 bug-reports:    https://github.com/flipstone/shrubbery/issues


### PR DESCRIPTION
I added two new functions to match specific types or tags in a `Union` or `TaggedUnion`, respectively. The functions return `Just` the matched type if the union values match the type or tag, and `Nothing` otherwise.

These functions are a lightweight alternative, both syntactically and performance-wise, to `dissect` when you only need to match on one branch.