### PR TITLE
Add INLINE pragma to several definitions

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                shrubbery
-version:             0.2.2.0
+version:             0.2.2.1
 github:              "flipstone/shrubbery"
 license:             BSD3
 author:              "Flipstone Technology Partners, Inc"
@@ -62,6 +62,7 @@ library:
           - -Wno-implicit-prelude
           - -Wno-safe
           - -Wno-unsafe
+
       else:
         ghc-options:
           - -O2

--- a/shrubbery.cabal
+++ b/shrubbery.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           shrubbery
-version:        0.2.2.0
+version:        0.2.2.1
 description:    Please see the README on GitHub at <https://github.com/flipstone/shrubbery#readme>
 homepage:       https://github.com/flipstone/shrubbery#readme
 bug-reports:    https://github.com/flipstone/shrubbery/issues

--- a/src/Shrubbery/BranchIndex.hs
+++ b/src/Shrubbery/BranchIndex.hs
@@ -191,6 +191,7 @@ indexOfTypeAt ::
   BranchIndex t types
 indexOfTypeAt =
   BranchIndex . fromInteger . natVal
+{-# INLINE indexOfTypeAt #-}
 
 {- |
   Retrieves the 'Int' representation of the branch index. It it up to the
@@ -199,6 +200,7 @@ indexOfTypeAt =
 branchIndexToInt :: BranchIndex t types -> Int
 branchIndexToInt (BranchIndex n) =
   n
+{-# INLINE branchIndexToInt #-}
 
 {- |
   Appends additional types to the end of the list of types for a branch index.

--- a/src/Shrubbery/Parser.hs
+++ b/src/Shrubbery/Parser.hs
@@ -108,10 +108,10 @@ parseOption = ConsParse
   of options however is desired.
 -}
 parse ::
-  (Unification sum, Functor f) =>
-  Parser f input (BranchTypes sum) ->
+  (Unification sumType, Functor f) =>
+  Parser f input (BranchTypes sumType) ->
   input ->
-  [f sum]
+  [f sumType]
 parse parser input =
   case parser of
     NilParse ->
@@ -126,15 +126,15 @@ parse parser input =
   union with the appropriate index and can later be differentiated.
 -}
 parseZipper ::
-  ( Unification sum
-  , BranchTypes sum ~ ZippedTypes front a back
+  ( Unification sumType
+  , BranchTypes sumType ~ ZippedTypes front a back
   , Functor f
   ) =>
   (input -> f a) ->
   Parser f input back ->
   TypeZipper front a back ->
   input ->
-  [f sum]
+  [f sumType]
 parseZipper f parseRest zipper input =
   let
     item =

--- a/src/Shrubbery/TypeList.hs
+++ b/src/Shrubbery/TypeList.hs
@@ -119,11 +119,11 @@ type OutOfBoundsMsg (index :: Nat) (types :: [Type]) =
 class KnownLength (types :: [k]) where
   lengthOfTypes :: proxy types -> Int
 
-instance (KnownNat length, length ~ Length types) => KnownLength types where
+instance (KnownNat suppliedLength, suppliedLength ~ Length types) => KnownLength types where
   lengthOfTypes =
     fromInteger . natVal . typesProxyToLengthProxy
 
-typesProxyToLengthProxy :: length ~ Length types => proxy types -> Proxy length
+typesProxyToLengthProxy :: suppliedLength ~ Length types => proxy types -> Proxy suppliedLength
 typesProxyToLengthProxy _ = Proxy
 
 {- |

--- a/src/Shrubbery/Union.hs
+++ b/src/Shrubbery/Union.hs
@@ -97,6 +97,7 @@ dissectUnion ::
   result
 dissectUnion branches (Union branchIndex t) =
   selectBranchAtIndex branchIndex branches t
+{-# INLINE dissectUnion #-}
 
 {- |
   Matches a 'Union' against one of its types, returning 'Just' the value if the


### PR DESCRIPTION
- INLINE is added to many definitions

- A handful of definitions are written in a more compact form, as that will be copied during inlining.

- Made some operations use Applicative instead of Monad

- Updates some type variables for term-variable-capture, that is introduced in ghc 9.8

This has been tested on a real world workload with, nontrivial, positive effect.