### PR TITLE
Adds `Ord` instances to `Union` and `TaggedUnion`

### DIFF
--- a/src/Shrubbery/TaggedUnion.hs
+++ b/src/Shrubbery/TaggedUnion.hs
@@ -32,7 +32,7 @@ import GHC.TypeLits (KnownNat, Symbol)
 import Data.Type.Equality ((:~:) (..))
 import Shrubbery.BranchIndex (indexOfTypeAt, testBranchIndexEquality)
 import Shrubbery.Branches (BranchBuilder, Branches, appendBranches, branchBuild, branchDefault, branchEnd, branchSetAtIndex, singleBranch)
-import Shrubbery.Classes (EqBranches, NFDataBranches, ShowBranches, unifyWithIndex)
+import Shrubbery.Classes (EqBranches, NFDataBranches, OrdBranches, ShowBranches, unifyWithIndex)
 import Shrubbery.TypeList (Append, KnownLength, Tag (..), TagIndex, TagType, TaggedTypes, TypeAtIndex, type (@=))
 import Shrubbery.Union (Union (Union), dissectUnion)
 
@@ -70,6 +70,19 @@ instance
   (==) (TaggedUnion left) (TaggedUnion right) =
     left == right
   {-# INLINE (==) #-}
+
+instance
+  ( TaggedTypes taggedTypes ~ types
+  , types ~ (first : rest)
+  , EqBranches types
+  , OrdBranches types
+  , KnownLength types
+  ) =>
+  Ord (TaggedUnion taggedTypes)
+  where
+  compare (TaggedUnion left) (TaggedUnion right) =
+    compare left right
+  {-# INLINE compare #-}
 
 instance
   ( TaggedTypes taggedTypes ~ types

--- a/src/Shrubbery/Union.hs
+++ b/src/Shrubbery/Union.hs
@@ -59,11 +59,11 @@ module Shrubbery.Union
 
 import qualified Control.DeepSeq as DeepSeq
 import Data.Type.Equality ((:~:) (..))
-
 import GHC.TypeLits (KnownNat)
+
 import Shrubbery.BranchIndex (BranchIndex, firstIndexOfType, testBranchIndexEquality)
 import Shrubbery.Branches (Branches, selectBranchAtIndex)
-import Shrubbery.Classes (BranchTypes, Dissection (..), EqBranches, NFDataBranches, ShowBranches, Unification (..), eqViaDissect, rnfViaDissect, showsPrecViaDissect)
+import Shrubbery.Classes (BranchTypes, Dissection (..), EqBranches, NFDataBranches, OrdBranches, ShowBranches, Unification (..), compareViaDissect, eqViaDissect, rnfViaDissect, showsPrecViaDissect)
 import Shrubbery.TypeList (FirstIndexOf, KnownLength)
 
 {- |
@@ -79,6 +79,9 @@ instance (ShowBranches types, KnownLength types) => Show (Union types) where
 
 instance (EqBranches types, KnownLength types, types ~ (first : rest)) => Eq (Union types) where
   (==) = eqViaDissect
+
+instance (EqBranches types, OrdBranches types, KnownLength types, types ~ (first : rest)) => Ord (Union types) where
+  compare = compareViaDissect
 
 instance (NFDataBranches types, KnownLength types) => DeepSeq.NFData (Union types) where
   rnf = rnfViaDissect


### PR DESCRIPTION
We added the instances following the same pattern as the existing `Eq` instance. This involved adding a function called
`branchDefaultWithIndex` that allows the default result to depend on the integer index of the branch so that we can correctly return `LT` or `GT` depending on branch indexes of the unions being compared.