### PR TITLE
Adds `Ord` instances to `Union` and `TaggedUnion`

### DIFF
--- a/src/Shrubbery/Classes.hs
+++ b/src/Shrubbery/Classes.hs
@@ -44,16 +44,18 @@ module Shrubbery.Classes
   , showsPrecViaDissect
   , EqBranches
   , eqViaDissect
+  , OrdBranches
+  , compareViaDissect
   , NFDataBranches
   , rnfViaDissect
   ) where
 
 import qualified Control.DeepSeq as DeepSeq
-import Data.Kind (Type)
+import Data.Kind (Constraint, Type)
 import GHC.TypeLits (KnownNat)
 
-import Shrubbery.BranchIndex (BranchIndex, TypeZipper, firstIndexOfType, indexOfFocusedType, moveZipperNext, startZipper)
-import Shrubbery.Branches (BranchBuilder, Branches, branch, branchBuild, branchDefault, branchEnd, branchSetAtIndex)
+import Shrubbery.BranchIndex (BranchIndex, TypeZipper, branchIndexToInt, firstIndexOfType, indexOfFocusedType, moveZipperNext, startZipper)
+import Shrubbery.Branches (BranchBuilder, Branches, branch, branchBuild, branchDefault, branchDefaultWithIndex, branchEnd, branchSetAtIndex)
 import Shrubbery.TypeList (FirstIndexOf, KnownLength, ZippedTypes)
 
 {- |
@@ -137,12 +139,12 @@ showsPrecViaDissect ::
 showsPrecViaDissect prec a =
   dissect (branchBuild showsPrecBranches) a prec
 
-data EqBranchesList (allTypes :: [Type]) (someTypes :: [Type]) where
-  EqBranchesNil :: EqBranchesList allTypes '[]
-  EqBranchesCons ::
-    Eq a =>
-    EqBranchesList allTypes types ->
-    EqBranchesList allTypes (a : types)
+data BranchesList (c :: Type -> Constraint) (allTypes :: [Type]) (someTypes :: [Type]) where
+  BranchesNil :: BranchesList c allTypes '[]
+  BranchesCons ::
+    c a =>
+    BranchesList c allTypes types ->
+    BranchesList c allTypes (a : types)
 
 {- |
   'EqBranches' is provided as a convenience for implementing 'Eq' on
@@ -150,15 +152,31 @@ data EqBranchesList (allTypes :: [Type]) (someTypes :: [Type]) where
   way to make use of this.
 -}
 class EqBranches types where
-  eqBranchesList :: EqBranchesList allTypes types
+  eqBranchesList :: BranchesList Eq allTypes types
 
 instance EqBranches '[] where
   eqBranchesList =
-    EqBranchesNil
+    BranchesNil
 
 instance (Eq a, EqBranches rest) => EqBranches (a : rest) where
   eqBranchesList =
-    EqBranchesCons eqBranchesList
+    BranchesCons eqBranchesList
+
+{- |
+  'OrdBranches' is provided as a convenience for implementing 'Ord' on
+  sum types via 'Dissection'. See 'compareViaDissect' for the most common
+  way to make use of this.
+-}
+class OrdBranches types where
+  compareBranchesList :: BranchesList Ord allTypes types
+
+instance OrdBranches '[] where
+  compareBranchesList =
+    BranchesNil
+
+instance (Ord a, OrdBranches rest) => OrdBranches (a : rest) where
+  compareBranchesList =
+    BranchesCons compareBranchesList
 
 {- |
   'eqViaDissect' can be used as the implementation of '==' for an 'Eq' instance
@@ -174,8 +192,8 @@ eqViaDissect ::
   a ->
   a ->
   Bool
-eqViaDissect a =
-  dissect (dissect eqBranches a)
+eqViaDissect x =
+  dissect (dissect eqBranches x)
 
 eqBranches ::
   ( EqBranches types
@@ -190,25 +208,81 @@ eqBranches =
       , allTypes ~ ZippedTypes front focus rest
       ) =>
       TypeZipper front focus rest ->
-      EqBranchesList allTypes (focus : rest) ->
+      BranchesList Eq allTypes (focus : rest) ->
       BranchBuilder (focus : rest) (Branches allTypes Bool)
     go zipper eb =
       case eb of
-        EqBranchesCons eqBranchesRest ->
+        BranchesCons eqBranchesRest ->
           let
             index =
               indexOfFocusedType zipper
 
             branchesRest =
               case eqBranchesRest of
-                EqBranchesNil -> branchEnd
-                EqBranchesCons _ -> go (moveZipperNext zipper) eqBranchesRest
+                BranchesNil -> branchEnd
+                BranchesCons _ -> go (moveZipperNext zipper) eqBranchesRest
           in
             branch
               (\a -> branchBuild . branchSetAtIndex index (a ==) $ branchDefault False)
               branchesRest
   in
     branchBuild $ go startZipper eqBranchesList
+
+{- |
+  'compareViaDissect' can be used as the implementation of '==' for an 'Ord' instance
+  for types that implement 'Dissection' when all the  member types implement 'Ord'
+-}
+compareViaDissect ::
+  ( Dissection a
+  , types ~ BranchTypes a
+  , OrdBranches types
+  , KnownLength types
+  , types ~ (first : rest)
+  ) =>
+  a ->
+  a ->
+  Ordering
+compareViaDissect x =
+  dissect (dissect compareBranches x)
+
+compareBranches ::
+  ( OrdBranches types
+  , KnownLength types
+  , types ~ (first : rest)
+  ) =>
+  Branches types (Branches types Ordering)
+compareBranches =
+  let
+    go ::
+      ( KnownLength allTypes
+      , allTypes ~ ZippedTypes front focus rest
+      ) =>
+      TypeZipper front focus rest ->
+      BranchesList Ord allTypes (focus : rest) ->
+      BranchBuilder (focus : rest) (Branches allTypes Ordering)
+    go zipper eb =
+      case eb of
+        BranchesCons compareBranchesRest ->
+          let
+            index =
+              indexOfFocusedType zipper
+
+            indexInt =
+              branchIndexToInt index
+
+            branchesRest =
+              case compareBranchesRest of
+                BranchesNil -> branchEnd
+                BranchesCons _ -> go (moveZipperNext zipper) compareBranchesRest
+
+            defaultComparison =
+              branchDefaultWithIndex (indexInt `compare`)
+          in
+            branch
+              (\a -> branchBuild $ branchSetAtIndex index (a `compare`) defaultComparison)
+              branchesRest
+  in
+    branchBuild $ go startZipper compareBranchesList
 
 {- |
   'rnfViaDissect' can be used as the implementation of 'DeepSeq.rnf' in the

--- a/src/Shrubbery/TaggedUnion.hs
+++ b/src/Shrubbery/TaggedUnion.hs
@@ -32,7 +32,7 @@ import GHC.TypeLits (KnownNat, Symbol)
 import Data.Type.Equality ((:~:) (..))
 import Shrubbery.BranchIndex (indexOfTypeAt, testBranchIndexEquality)
 import Shrubbery.Branches (BranchBuilder, Branches, appendBranches, branchBuild, branchDefault, branchEnd, branchSetAtIndex, singleBranch)
-import Shrubbery.Classes (EqBranches, NFDataBranches, ShowBranches, unifyWithIndex)
+import Shrubbery.Classes (EqBranches, NFDataBranches, OrdBranches, ShowBranches, unifyWithIndex)
 import Shrubbery.TypeList (Append, KnownLength, Tag (..), TagIndex, TagType, TaggedTypes, TypeAtIndex, type (@=))
 import Shrubbery.Union (Union (Union), dissectUnion)
 
@@ -70,6 +70,19 @@ instance
   (==) (TaggedUnion left) (TaggedUnion right) =
     left == right
   {-# INLINE (==) #-}
+
+instance
+  ( TaggedTypes taggedTypes ~ types
+  , types ~ (first : rest)
+  , EqBranches types
+  , OrdBranches types
+  , KnownLength types
+  ) =>
+  Ord (TaggedUnion taggedTypes)
+  where
+  compare (TaggedUnion left) (TaggedUnion right) =
+    compare left right
+  {-# INLINE compare #-}
 
 instance
   ( TaggedTypes taggedTypes ~ types

--- a/src/Shrubbery/Union.hs
+++ b/src/Shrubbery/Union.hs
@@ -59,11 +59,11 @@ module Shrubbery.Union
 
 import qualified Control.DeepSeq as DeepSeq
 import Data.Type.Equality ((:~:) (..))
-
 import GHC.TypeLits (KnownNat)
+
 import Shrubbery.BranchIndex (BranchIndex, firstIndexOfType, testBranchIndexEquality)
 import Shrubbery.Branches (Branches, selectBranchAtIndex)
-import Shrubbery.Classes (BranchTypes, Dissection (..), EqBranches, NFDataBranches, ShowBranches, Unification (..), eqViaDissect, rnfViaDissect, showsPrecViaDissect)
+import Shrubbery.Classes (BranchTypes, Dissection (..), EqBranches, NFDataBranches, OrdBranches, ShowBranches, Unification (..), compareViaDissect, eqViaDissect, rnfViaDissect, showsPrecViaDissect)
 import Shrubbery.TypeList (FirstIndexOf, KnownLength)
 
 {- |
@@ -79,6 +79,9 @@ instance (ShowBranches types, KnownLength types) => Show (Union types) where
 
 instance (EqBranches types, KnownLength types, types ~ (first : rest)) => Eq (Union types) where
   (==) = eqViaDissect
+
+instance (EqBranches types, OrdBranches types, KnownLength types, types ~ (first : rest)) => Ord (Union types) where
+  compare = compareViaDissect
 
 instance (NFDataBranches types, KnownLength types) => DeepSeq.NFData (Union types) where
   rnf = rnfViaDissect


### PR DESCRIPTION
We added the instances following the same pattern as the existing `Eq` instance. This involved adding a function called
`branchDefaultWithIndex` that allows the default result to depend on the integer index of the branch so that we can correctly return `LT` or `GT` depending on branch indexes of the unions being compared.