### PR TITLE
Eta reduces `eq`/`compareViaDissect`

### DIFF
--- a/src/Shrubbery/Classes.hs
+++ b/src/Shrubbery/Classes.hs
@@ -192,8 +192,8 @@ eqViaDissect ::
   a ->
   a ->
   Bool
-eqViaDissect x =
-  dissect (dissect eqBranches x)
+eqViaDissect =
+  dissect . dissect eqBranches
 
 eqBranches ::
   ( EqBranches types
@@ -242,8 +242,8 @@ compareViaDissect ::
   a ->
   a ->
   Ordering
-compareViaDissect x =
-  dissect (dissect compareBranches x)
+compareViaDissect =
+  dissect . dissect compareBranches
 
 compareBranches ::
   ( OrdBranches types


### PR DESCRIPTION
Local microbenchmarking shows the eta reduction can make comparison up to 10x faster.